### PR TITLE
Create q a tag keyword tables

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "cSpell.words": [
+    "Knowbot"
+  ]
+}

--- a/config/config.exs
+++ b/config/config.exs
@@ -47,7 +47,7 @@ config :logger, :console,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
-# Discord bot config:
+# ORIGINAL Discord bot config:
 config :nostrum,
   token: System.get_env("NOSTRUM_TOKEN"),
   gateway_intents: [:guild_messages, :guilds, :message_content]

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,5 +1,10 @@
 import Config
 
+# Discord bot config:
+config :nostrum,
+  token: System.get_env("NOSTRUM_TOKEN"),
+  gateway_intents: [:guild_messages, :guilds, :message_content]
+
 # Configure your database
 config :knowbot, Knowbot.Repo,
   username: "postgres",

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -19,7 +19,7 @@ config :knowbot, Knowbot.Repo,
 config :knowbot, KnowbotWeb.Endpoint,
   # Binding to loopback ipv4 address prevents access from other machines.
   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
-  http: [ip: {127, 0, 0, 1}, port: 4000],
+  http: [ip: {127, 0, 0, 1}, port: 4021],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -2,7 +2,13 @@ import Config
 # Dotenvy:
 import Dotenvy
 
-source!(["../.env", System.get_env()]) # Dotenvy
+source!([".env", System.get_env()]) # Dotenvy
+
+# JSH Guess, re: location of this that will work:
+# # Discord bot config:
+# config :nostrum,
+#   token: System.get_env("NOSTRUM_TOKEN"),
+#   gateway_intents: [:guild_messages, :guilds, :message_content]
 
 # config/runtime.exs is executed for all environments, including
 # during releases. It is executed after compilation and before the

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,13 @@
 import Config
+# Dotenvy:
+import Dotenvy
+
+source!([".env", System.get_env()]) # Dotenvy(?)
+
+# Discord bot config:
+config :nostrum,
+  token: System.get_env("NOSTRUM_TOKEN"),
+  gateway_intents: [:guild_messages, :guilds, :message_content]
 
 # Configure your database
 #

--- a/lib/knowbot/answers.ex
+++ b/lib/knowbot/answers.ex
@@ -1,0 +1,104 @@
+defmodule Knowbot.Answers do
+  @moduledoc """
+  The Answers context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Knowbot.Repo
+
+  alias Knowbot.Answers.Answer
+
+  @doc """
+  Returns the list of answers.
+
+  ## Examples
+
+      iex> list_answers()
+      [%Answer{}, ...]
+
+  """
+  def list_answers do
+    Repo.all(Answer)
+  end
+
+  @doc """
+  Gets a single answer.
+
+  Raises `Ecto.NoResultsError` if the Answer does not exist.
+
+  ## Examples
+
+      iex> get_answer!(123)
+      %Answer{}
+
+      iex> get_answer!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_answer!(id), do: Repo.get!(Answer, id)
+
+  @doc """
+  Creates a answer.
+
+  ## Examples
+
+      iex> create_answer(%{field: value})
+      {:ok, %Answer{}}
+
+      iex> create_answer(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_answer(attrs \\ %{}) do
+    %Answer{}
+    |> Answer.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a answer.
+
+  ## Examples
+
+      iex> update_answer(answer, %{field: new_value})
+      {:ok, %Answer{}}
+
+      iex> update_answer(answer, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_answer(%Answer{} = answer, attrs) do
+    answer
+    |> Answer.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a answer.
+
+  ## Examples
+
+      iex> delete_answer(answer)
+      {:ok, %Answer{}}
+
+      iex> delete_answer(answer)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_answer(%Answer{} = answer) do
+    Repo.delete(answer)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking answer changes.
+
+  ## Examples
+
+      iex> change_answer(answer)
+      %Ecto.Changeset{data: %Answer{}}
+
+  """
+  def change_answer(%Answer{} = answer, attrs \\ %{}) do
+    Answer.changeset(answer, attrs)
+  end
+end

--- a/lib/knowbot/answers/answer.ex
+++ b/lib/knowbot/answers/answer.ex
@@ -1,0 +1,18 @@
+defmodule Knowbot.Answers.Answer do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "answers" do
+    field :answered_by, :string
+    field :content, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(answer, attrs) do
+    answer
+    |> cast(attrs, [:content, :answered_by])
+    |> validate_required([:content, :answered_by])
+  end
+end

--- a/lib/knowbot/consumer.ex
+++ b/lib/knowbot/consumer.ex
@@ -6,14 +6,13 @@ defmodule Knowbot.Consumer do
   @help_content ~S"""
   **KnowBot**: Your learning assistant. Like you, I'm getting smarter every day.
 
-  Each command starts with \"**!**\" (the \"bang\" character).
+  Each command starts with \"**!**\" (the \"bang\" character [shift-1]).
   **!h** or **!help** - Gets you this help content.
   **!q** - Ask a question. EXAMPLES:
          !q How do I use Enum?
          !q Enum?
          !q Enum.filter?
-      I start with the **?**. I assume the most important word has the question
-      mark after it.
+      I start with the **?**. I assume the most important word has the question mark after it.
   **!faq** - show the Frequently Asked Questions (FAQs).
   """
   def start_link do
@@ -22,37 +21,50 @@ defmodule Knowbot.Consumer do
 
   def handle_event({:MESSAGE_CREATE, msg, _ws_state}) do
     # IO.inspect(msg.content, label: "handle_event")
+    # cond do
+    #   ...>   2 + 2 == 5 ->
+    #   ...>     "This is never true"
+    #   ...>   2 * 2 == 3 ->
+    #   ...>     "Nor this"
+    #   ...>   true ->
+    #   ...>     "This is always true (equivalent to else)"
+    #   ...> end
+    # String.downcase(msg.content) |> case msg_content do
+    msg_content = String.downcase(msg.content)
+    # case String.downcase(msg.content) do
+    cond do
+      #  String.starts_with(msg_content, "!q") -> # ... the rest is search_phrase
+      #   search_term =
+      #     msg_content
+      #     |> String.split
+      #     |> Enum.filter(fn word -> String.ends_with?(word, "?") end)
+      #     |> List.first
+      #     |> String.trim_trailing("?")
+      #   # search_results = search_by(search_term)
+      #   |> Api.create_message(msg.channel_id)
 
-    case String.downcase(msg.content) do
-      # starts_with("!q") and the rest is search_phrase ->
-        search term =
-          search_phrase
-          |> String.split
-          |> Enum.filter(fn word -> String.ends_with?(word, "?") end)
-          |> List.first
-          |> String.trim_trailing("?")
-        # search_results = search_by(search_term)
-        # Api.create_message(msg.channel_id, search_results)
-
-      "!sleep" ->
+      msg_content == "!sleep" ->
         Api.create_message(msg.channel_id, "Going to sleep...")
         # This won't stop other events from being handled.
         Process.sleep(3000)
 
-      "!ping" ->
-        Api.create_message(msg.channel_id, "Hello Discord! I am your KnowBot.")
+      msg_content == "!ping" ->
+        Api.create_message(msg.channel_id, "Hello DY Academy! I am your KnowBot.")
 
-      "!h" ->
+      # msg_content == "!h" ->
+      #   Api.create_message(msg.channel_id, @help_content)
+      #   user = userManager.GetCurrentUser()
+      #   Console.WriteLine("Connected to user {0}", user.Id);
+
+      msg_content == "!help" ->
         Api.create_message(msg.channel_id, @help_content)
 
-      "!help" ->
-        Api.create_message(msg.channel_id, @help_content)
-
-      "!raise" ->
+      msg_content == "!raise" ->
         # This won't crash the entire Consumer.
         raise "No problems here!"
 
-      _ ->
+      # _ -> # FOR CASE STATEMENT ONLY
+      true ->
         :ignore
     end
   end

--- a/lib/knowbot/keywords.ex
+++ b/lib/knowbot/keywords.ex
@@ -1,0 +1,104 @@
+defmodule Knowbot.Keywords do
+  @moduledoc """
+  The Keywords context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Knowbot.Repo
+
+  alias Knowbot.Keywords.Keyword
+
+  @doc """
+  Returns the list of keywords.
+
+  ## Examples
+
+      iex> list_keywords()
+      [%Keyword{}, ...]
+
+  """
+  def list_keywords do
+    Repo.all(Keyword)
+  end
+
+  @doc """
+  Gets a single keyword.
+
+  Raises `Ecto.NoResultsError` if the Keyword does not exist.
+
+  ## Examples
+
+      iex> get_keyword!(123)
+      %Keyword{}
+
+      iex> get_keyword!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_keyword!(id), do: Repo.get!(Keyword, id)
+
+  @doc """
+  Creates a keyword.
+
+  ## Examples
+
+      iex> create_keyword(%{field: value})
+      {:ok, %Keyword{}}
+
+      iex> create_keyword(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_keyword(attrs \\ %{}) do
+    %Keyword{}
+    |> Keyword.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a keyword.
+
+  ## Examples
+
+      iex> update_keyword(keyword, %{field: new_value})
+      {:ok, %Keyword{}}
+
+      iex> update_keyword(keyword, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_keyword(%Keyword{} = keyword, attrs) do
+    keyword
+    |> Keyword.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a keyword.
+
+  ## Examples
+
+      iex> delete_keyword(keyword)
+      {:ok, %Keyword{}}
+
+      iex> delete_keyword(keyword)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_keyword(%Keyword{} = keyword) do
+    Repo.delete(keyword)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking keyword changes.
+
+  ## Examples
+
+      iex> change_keyword(keyword)
+      %Ecto.Changeset{data: %Keyword{}}
+
+  """
+  def change_keyword(%Keyword{} = keyword, attrs \\ %{}) do
+    Keyword.changeset(keyword, attrs)
+  end
+end

--- a/lib/knowbot/keywords/keyword.ex
+++ b/lib/knowbot/keywords/keyword.ex
@@ -1,0 +1,17 @@
+defmodule Knowbot.Keywords.Keyword do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "keywords" do
+    field :name, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(keyword, attrs) do
+    keyword
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+  end
+end

--- a/lib/knowbot/questions.ex
+++ b/lib/knowbot/questions.ex
@@ -1,0 +1,104 @@
+defmodule Knowbot.Questions do
+  @moduledoc """
+  The Questions context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Knowbot.Repo
+
+  alias Knowbot.Questions.Question
+
+  @doc """
+  Returns the list of questions.
+
+  ## Examples
+
+      iex> list_questions()
+      [%Question{}, ...]
+
+  """
+  def list_questions do
+    Repo.all(Question)
+  end
+
+  @doc """
+  Gets a single question.
+
+  Raises `Ecto.NoResultsError` if the Question does not exist.
+
+  ## Examples
+
+      iex> get_question!(123)
+      %Question{}
+
+      iex> get_question!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_question!(id), do: Repo.get!(Question, id)
+
+  @doc """
+  Creates a question.
+
+  ## Examples
+
+      iex> create_question(%{field: value})
+      {:ok, %Question{}}
+
+      iex> create_question(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_question(attrs \\ %{}) do
+    %Question{}
+    |> Question.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a question.
+
+  ## Examples
+
+      iex> update_question(question, %{field: new_value})
+      {:ok, %Question{}}
+
+      iex> update_question(question, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_question(%Question{} = question, attrs) do
+    question
+    |> Question.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a question.
+
+  ## Examples
+
+      iex> delete_question(question)
+      {:ok, %Question{}}
+
+      iex> delete_question(question)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_question(%Question{} = question) do
+    Repo.delete(question)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking question changes.
+
+  ## Examples
+
+      iex> change_question(question)
+      %Ecto.Changeset{data: %Question{}}
+
+  """
+  def change_question(%Question{} = question, attrs \\ %{}) do
+    Question.changeset(question, attrs)
+  end
+end

--- a/lib/knowbot/questions/question.ex
+++ b/lib/knowbot/questions/question.ex
@@ -13,6 +13,6 @@ defmodule Knowbot.Questions.Question do
   def changeset(question, attrs) do
     question
     |> cast(attrs, [:content, :asker])
-    |> validate_required([:content, :asker])
+    |> validate_required([:content]) # , :asker #... later
   end
 end

--- a/lib/knowbot/questions/question.ex
+++ b/lib/knowbot/questions/question.ex
@@ -1,0 +1,18 @@
+defmodule Knowbot.Questions.Question do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "questions" do
+    field :asker, :string
+    field :content, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(question, attrs) do
+    question
+    |> cast(attrs, [:content, :asker])
+    |> validate_required([:content, :asker])
+  end
+end

--- a/lib/knowbot/tags.ex
+++ b/lib/knowbot/tags.ex
@@ -1,0 +1,104 @@
+defmodule Knowbot.Tags do
+  @moduledoc """
+  The Tags context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Knowbot.Repo
+
+  alias Knowbot.Tags.Tag
+
+  @doc """
+  Returns the list of tags.
+
+  ## Examples
+
+      iex> list_tags()
+      [%Tag{}, ...]
+
+  """
+  def list_tags do
+    Repo.all(Tag)
+  end
+
+  @doc """
+  Gets a single tag.
+
+  Raises `Ecto.NoResultsError` if the Tag does not exist.
+
+  ## Examples
+
+      iex> get_tag!(123)
+      %Tag{}
+
+      iex> get_tag!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_tag!(id), do: Repo.get!(Tag, id)
+
+  @doc """
+  Creates a tag.
+
+  ## Examples
+
+      iex> create_tag(%{field: value})
+      {:ok, %Tag{}}
+
+      iex> create_tag(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_tag(attrs \\ %{}) do
+    %Tag{}
+    |> Tag.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a tag.
+
+  ## Examples
+
+      iex> update_tag(tag, %{field: new_value})
+      {:ok, %Tag{}}
+
+      iex> update_tag(tag, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_tag(%Tag{} = tag, attrs) do
+    tag
+    |> Tag.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a tag.
+
+  ## Examples
+
+      iex> delete_tag(tag)
+      {:ok, %Tag{}}
+
+      iex> delete_tag(tag)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_tag(%Tag{} = tag) do
+    Repo.delete(tag)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking tag changes.
+
+  ## Examples
+
+      iex> change_tag(tag)
+      %Ecto.Changeset{data: %Tag{}}
+
+  """
+  def change_tag(%Tag{} = tag, attrs \\ %{}) do
+    Tag.changeset(tag, attrs)
+  end
+end

--- a/lib/knowbot/tags/tag.ex
+++ b/lib/knowbot/tags/tag.ex
@@ -1,0 +1,17 @@
+defmodule Knowbot.Tags.Tag do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "tags" do
+    field :name, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(tag, attrs) do
+    tag
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+  end
+end

--- a/lib/knowbot_web/controllers/answer_controller.ex
+++ b/lib/knowbot_web/controllers/answer_controller.ex
@@ -1,0 +1,62 @@
+defmodule KnowbotWeb.AnswerController do
+  use KnowbotWeb, :controller
+
+  alias Knowbot.Answers
+  alias Knowbot.Answers.Answer
+
+  def index(conn, _params) do
+    answers = Answers.list_answers()
+    render(conn, "index.html", answers: answers)
+  end
+
+  def new(conn, _params) do
+    changeset = Answers.change_answer(%Answer{})
+    render(conn, "new.html", changeset: changeset)
+  end
+
+  def create(conn, %{"answer" => answer_params}) do
+    case Answers.create_answer(answer_params) do
+      {:ok, answer} ->
+        conn
+        |> put_flash(:info, "Answer created successfully.")
+        |> redirect(to: Routes.answer_path(conn, :show, answer))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "new.html", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    answer = Answers.get_answer!(id)
+    render(conn, "show.html", answer: answer)
+  end
+
+  def edit(conn, %{"id" => id}) do
+    answer = Answers.get_answer!(id)
+    changeset = Answers.change_answer(answer)
+    render(conn, "edit.html", answer: answer, changeset: changeset)
+  end
+
+  def update(conn, %{"id" => id, "answer" => answer_params}) do
+    answer = Answers.get_answer!(id)
+
+    case Answers.update_answer(answer, answer_params) do
+      {:ok, answer} ->
+        conn
+        |> put_flash(:info, "Answer updated successfully.")
+        |> redirect(to: Routes.answer_path(conn, :show, answer))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "edit.html", answer: answer, changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    answer = Answers.get_answer!(id)
+    {:ok, _answer} = Answers.delete_answer(answer)
+
+    conn
+    |> put_flash(:info, "Answer deleted successfully.")
+    |> redirect(to: Routes.answer_path(conn, :index))
+  end
+end

--- a/lib/knowbot_web/controllers/keyword_controller.ex
+++ b/lib/knowbot_web/controllers/keyword_controller.ex
@@ -1,0 +1,62 @@
+defmodule KnowbotWeb.KeywordController do
+  use KnowbotWeb, :controller
+
+  alias Knowbot.Keywords
+  alias Knowbot.Keywords.Keyword
+
+  def index(conn, _params) do
+    keywords = Keywords.list_keywords()
+    render(conn, "index.html", keywords: keywords)
+  end
+
+  def new(conn, _params) do
+    changeset = Keywords.change_keyword(%Keyword{})
+    render(conn, "new.html", changeset: changeset)
+  end
+
+  def create(conn, %{"keyword" => keyword_params}) do
+    case Keywords.create_keyword(keyword_params) do
+      {:ok, keyword} ->
+        conn
+        |> put_flash(:info, "Keyword created successfully.")
+        |> redirect(to: Routes.keyword_path(conn, :show, keyword))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "new.html", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    keyword = Keywords.get_keyword!(id)
+    render(conn, "show.html", keyword: keyword)
+  end
+
+  def edit(conn, %{"id" => id}) do
+    keyword = Keywords.get_keyword!(id)
+    changeset = Keywords.change_keyword(keyword)
+    render(conn, "edit.html", keyword: keyword, changeset: changeset)
+  end
+
+  def update(conn, %{"id" => id, "keyword" => keyword_params}) do
+    keyword = Keywords.get_keyword!(id)
+
+    case Keywords.update_keyword(keyword, keyword_params) do
+      {:ok, keyword} ->
+        conn
+        |> put_flash(:info, "Keyword updated successfully.")
+        |> redirect(to: Routes.keyword_path(conn, :show, keyword))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "edit.html", keyword: keyword, changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    keyword = Keywords.get_keyword!(id)
+    {:ok, _keyword} = Keywords.delete_keyword(keyword)
+
+    conn
+    |> put_flash(:info, "Keyword deleted successfully.")
+    |> redirect(to: Routes.keyword_path(conn, :index))
+  end
+end

--- a/lib/knowbot_web/controllers/question_controller.ex
+++ b/lib/knowbot_web/controllers/question_controller.ex
@@ -1,0 +1,62 @@
+defmodule KnowbotWeb.QuestionController do
+  use KnowbotWeb, :controller
+
+  alias Knowbot.Questions
+  alias Knowbot.Questions.Question
+
+  def index(conn, _params) do
+    questions = Questions.list_questions()
+    render(conn, "index.html", questions: questions)
+  end
+
+  def new(conn, _params) do
+    changeset = Questions.change_question(%Question{})
+    render(conn, "new.html", changeset: changeset)
+  end
+
+  def create(conn, %{"question" => question_params}) do
+    case Questions.create_question(question_params) do
+      {:ok, question} ->
+        conn
+        |> put_flash(:info, "Question created successfully.")
+        |> redirect(to: Routes.question_path(conn, :show, question))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "new.html", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    question = Questions.get_question!(id)
+    render(conn, "show.html", question: question)
+  end
+
+  def edit(conn, %{"id" => id}) do
+    question = Questions.get_question!(id)
+    changeset = Questions.change_question(question)
+    render(conn, "edit.html", question: question, changeset: changeset)
+  end
+
+  def update(conn, %{"id" => id, "question" => question_params}) do
+    question = Questions.get_question!(id)
+
+    case Questions.update_question(question, question_params) do
+      {:ok, question} ->
+        conn
+        |> put_flash(:info, "Question updated successfully.")
+        |> redirect(to: Routes.question_path(conn, :show, question))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "edit.html", question: question, changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    question = Questions.get_question!(id)
+    {:ok, _question} = Questions.delete_question(question)
+
+    conn
+    |> put_flash(:info, "Question deleted successfully.")
+    |> redirect(to: Routes.question_path(conn, :index))
+  end
+end

--- a/lib/knowbot_web/controllers/tag_controller.ex
+++ b/lib/knowbot_web/controllers/tag_controller.ex
@@ -1,0 +1,62 @@
+defmodule KnowbotWeb.TagController do
+  use KnowbotWeb, :controller
+
+  alias Knowbot.Tags
+  alias Knowbot.Tags.Tag
+
+  def index(conn, _params) do
+    tags = Tags.list_tags()
+    render(conn, "index.html", tags: tags)
+  end
+
+  def new(conn, _params) do
+    changeset = Tags.change_tag(%Tag{})
+    render(conn, "new.html", changeset: changeset)
+  end
+
+  def create(conn, %{"tag" => tag_params}) do
+    case Tags.create_tag(tag_params) do
+      {:ok, tag} ->
+        conn
+        |> put_flash(:info, "Tag created successfully.")
+        |> redirect(to: Routes.tag_path(conn, :show, tag))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "new.html", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    tag = Tags.get_tag!(id)
+    render(conn, "show.html", tag: tag)
+  end
+
+  def edit(conn, %{"id" => id}) do
+    tag = Tags.get_tag!(id)
+    changeset = Tags.change_tag(tag)
+    render(conn, "edit.html", tag: tag, changeset: changeset)
+  end
+
+  def update(conn, %{"id" => id, "tag" => tag_params}) do
+    tag = Tags.get_tag!(id)
+
+    case Tags.update_tag(tag, tag_params) do
+      {:ok, tag} ->
+        conn
+        |> put_flash(:info, "Tag updated successfully.")
+        |> redirect(to: Routes.tag_path(conn, :show, tag))
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "edit.html", tag: tag, changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    tag = Tags.get_tag!(id)
+    {:ok, _tag} = Tags.delete_tag(tag)
+
+    conn
+    |> put_flash(:info, "Tag deleted successfully.")
+    |> redirect(to: Routes.tag_path(conn, :index))
+  end
+end

--- a/lib/knowbot_web/router.ex
+++ b/lib/knowbot_web/router.ex
@@ -18,6 +18,10 @@ defmodule KnowbotWeb.Router do
     pipe_through :browser
 
     get "/", PageController, :index
+    resources "/questions", QuestionController
+    resources "/answers", AnswerController
+    resources "/tags", TagController
+    resources "/keywords", KeywordController
   end
 
   # Other scopes may use custom stacks.

--- a/lib/knowbot_web/templates/answer/edit.html.heex
+++ b/lib/knowbot_web/templates/answer/edit.html.heex
@@ -1,0 +1,5 @@
+<h1>Edit Answer</h1>
+
+<%= render "form.html", Map.put(assigns, :action, Routes.answer_path(@conn, :update, @answer)) %>
+
+<span><%= link "Back", to: Routes.answer_path(@conn, :index) %></span>

--- a/lib/knowbot_web/templates/answer/form.html.heex
+++ b/lib/knowbot_web/templates/answer/form.html.heex
@@ -1,0 +1,19 @@
+<.form let={f} for={@changeset} action={@action}>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below.</p>
+    </div>
+  <% end %>
+
+  <%= label f, :content %>
+  <%= textarea f, :content %>
+  <%= error_tag f, :content %>
+
+  <%= label f, :answered_by %>
+  <%= text_input f, :answered_by %>
+  <%= error_tag f, :answered_by %>
+
+  <div>
+    <%= submit "Save" %>
+  </div>
+</.form>

--- a/lib/knowbot_web/templates/answer/index.html.heex
+++ b/lib/knowbot_web/templates/answer/index.html.heex
@@ -1,0 +1,28 @@
+<h1>Listing Answers</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Content</th>
+      <th>Answered by</th>
+
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+<%= for answer <- @answers do %>
+    <tr>
+      <td><%= answer.content %></td>
+      <td><%= answer.answered_by %></td>
+
+      <td>
+        <span><%= link "Show", to: Routes.answer_path(@conn, :show, answer) %></span>
+        <span><%= link "Edit", to: Routes.answer_path(@conn, :edit, answer) %></span>
+        <span><%= link "Delete", to: Routes.answer_path(@conn, :delete, answer), method: :delete, data: [confirm: "Are you sure?"] %></span>
+      </td>
+    </tr>
+<% end %>
+  </tbody>
+</table>
+
+<span><%= link "New Answer", to: Routes.answer_path(@conn, :new) %></span>

--- a/lib/knowbot_web/templates/answer/new.html.heex
+++ b/lib/knowbot_web/templates/answer/new.html.heex
@@ -1,0 +1,5 @@
+<h1>New Answer</h1>
+
+<%= render "form.html", Map.put(assigns, :action, Routes.answer_path(@conn, :create)) %>
+
+<span><%= link "Back", to: Routes.answer_path(@conn, :index) %></span>

--- a/lib/knowbot_web/templates/answer/show.html.heex
+++ b/lib/knowbot_web/templates/answer/show.html.heex
@@ -1,0 +1,18 @@
+<h1>Show Answer</h1>
+
+<ul>
+
+  <li>
+    <strong>Content:</strong>
+    <%= @answer.content %>
+  </li>
+
+  <li>
+    <strong>Answered by:</strong>
+    <%= @answer.answered_by %>
+  </li>
+
+</ul>
+
+<span><%= link "Edit", to: Routes.answer_path(@conn, :edit, @answer) %></span> |
+<span><%= link "Back", to: Routes.answer_path(@conn, :index) %></span>

--- a/lib/knowbot_web/templates/keyword/edit.html.heex
+++ b/lib/knowbot_web/templates/keyword/edit.html.heex
@@ -1,0 +1,5 @@
+<h1>Edit Keyword</h1>
+
+<%= render "form.html", Map.put(assigns, :action, Routes.keyword_path(@conn, :update, @keyword)) %>
+
+<span><%= link "Back", to: Routes.keyword_path(@conn, :index) %></span>

--- a/lib/knowbot_web/templates/keyword/form.html.heex
+++ b/lib/knowbot_web/templates/keyword/form.html.heex
@@ -1,0 +1,15 @@
+<.form let={f} for={@changeset} action={@action}>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below.</p>
+    </div>
+  <% end %>
+
+  <%= label f, :name %>
+  <%= text_input f, :name %>
+  <%= error_tag f, :name %>
+
+  <div>
+    <%= submit "Save" %>
+  </div>
+</.form>

--- a/lib/knowbot_web/templates/keyword/index.html.heex
+++ b/lib/knowbot_web/templates/keyword/index.html.heex
@@ -1,0 +1,26 @@
+<h1>Listing Keywords</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+<%= for keyword <- @keywords do %>
+    <tr>
+      <td><%= keyword.name %></td>
+
+      <td>
+        <span><%= link "Show", to: Routes.keyword_path(@conn, :show, keyword) %></span>
+        <span><%= link "Edit", to: Routes.keyword_path(@conn, :edit, keyword) %></span>
+        <span><%= link "Delete", to: Routes.keyword_path(@conn, :delete, keyword), method: :delete, data: [confirm: "Are you sure?"] %></span>
+      </td>
+    </tr>
+<% end %>
+  </tbody>
+</table>
+
+<span><%= link "New Keyword", to: Routes.keyword_path(@conn, :new) %></span>

--- a/lib/knowbot_web/templates/keyword/new.html.heex
+++ b/lib/knowbot_web/templates/keyword/new.html.heex
@@ -1,0 +1,5 @@
+<h1>New Keyword</h1>
+
+<%= render "form.html", Map.put(assigns, :action, Routes.keyword_path(@conn, :create)) %>
+
+<span><%= link "Back", to: Routes.keyword_path(@conn, :index) %></span>

--- a/lib/knowbot_web/templates/keyword/show.html.heex
+++ b/lib/knowbot_web/templates/keyword/show.html.heex
@@ -1,0 +1,13 @@
+<h1>Show Keyword</h1>
+
+<ul>
+
+  <li>
+    <strong>Name:</strong>
+    <%= @keyword.name %>
+  </li>
+
+</ul>
+
+<span><%= link "Edit", to: Routes.keyword_path(@conn, :edit, @keyword) %></span> |
+<span><%= link "Back", to: Routes.keyword_path(@conn, :index) %></span>

--- a/lib/knowbot_web/templates/question/edit.html.heex
+++ b/lib/knowbot_web/templates/question/edit.html.heex
@@ -1,0 +1,5 @@
+<h1>Edit Question</h1>
+
+<%= render "form.html", Map.put(assigns, :action, Routes.question_path(@conn, :update, @question)) %>
+
+<span><%= link "Back", to: Routes.question_path(@conn, :index) %></span>

--- a/lib/knowbot_web/templates/question/form.html.heex
+++ b/lib/knowbot_web/templates/question/form.html.heex
@@ -1,0 +1,19 @@
+<.form let={f} for={@changeset} action={@action}>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below.</p>
+    </div>
+  <% end %>
+
+  <%= label f, :content %>
+  <%= textarea f, :content %>
+  <%= error_tag f, :content %>
+
+  <%= label f, :asker %>
+  <%= text_input f, :asker %>
+  <%= error_tag f, :asker %>
+
+  <div>
+    <%= submit "Save" %>
+  </div>
+</.form>

--- a/lib/knowbot_web/templates/question/index.html.heex
+++ b/lib/knowbot_web/templates/question/index.html.heex
@@ -1,0 +1,28 @@
+<h1>Listing Questions</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Content</th>
+      <th>Asker</th>
+
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+<%= for question <- @questions do %>
+    <tr>
+      <td><%= question.content %></td>
+      <td><%= question.asker %></td>
+
+      <td>
+        <span><%= link "Show", to: Routes.question_path(@conn, :show, question) %></span>
+        <span><%= link "Edit", to: Routes.question_path(@conn, :edit, question) %></span>
+        <span><%= link "Delete", to: Routes.question_path(@conn, :delete, question), method: :delete, data: [confirm: "Are you sure?"] %></span>
+      </td>
+    </tr>
+<% end %>
+  </tbody>
+</table>
+
+<span><%= link "New Question", to: Routes.question_path(@conn, :new) %></span>

--- a/lib/knowbot_web/templates/question/new.html.heex
+++ b/lib/knowbot_web/templates/question/new.html.heex
@@ -1,0 +1,5 @@
+<h1>New Question</h1>
+
+<%= render "form.html", Map.put(assigns, :action, Routes.question_path(@conn, :create)) %>
+
+<span><%= link "Back", to: Routes.question_path(@conn, :index) %></span>

--- a/lib/knowbot_web/templates/question/show.html.heex
+++ b/lib/knowbot_web/templates/question/show.html.heex
@@ -1,0 +1,18 @@
+<h1>Show Question</h1>
+
+<ul>
+
+  <li>
+    <strong>Content:</strong>
+    <%= @question.content %>
+  </li>
+
+  <li>
+    <strong>Asker:</strong>
+    <%= @question.asker %>
+  </li>
+
+</ul>
+
+<span><%= link "Edit", to: Routes.question_path(@conn, :edit, @question) %></span> |
+<span><%= link "Back", to: Routes.question_path(@conn, :index) %></span>

--- a/lib/knowbot_web/templates/tag/edit.html.heex
+++ b/lib/knowbot_web/templates/tag/edit.html.heex
@@ -1,0 +1,5 @@
+<h1>Edit Tag</h1>
+
+<%= render "form.html", Map.put(assigns, :action, Routes.tag_path(@conn, :update, @tag)) %>
+
+<span><%= link "Back", to: Routes.tag_path(@conn, :index) %></span>

--- a/lib/knowbot_web/templates/tag/form.html.heex
+++ b/lib/knowbot_web/templates/tag/form.html.heex
@@ -1,0 +1,15 @@
+<.form let={f} for={@changeset} action={@action}>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below.</p>
+    </div>
+  <% end %>
+
+  <%= label f, :name %>
+  <%= text_input f, :name %>
+  <%= error_tag f, :name %>
+
+  <div>
+    <%= submit "Save" %>
+  </div>
+</.form>

--- a/lib/knowbot_web/templates/tag/index.html.heex
+++ b/lib/knowbot_web/templates/tag/index.html.heex
@@ -1,0 +1,26 @@
+<h1>Listing Tags</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+<%= for tag <- @tags do %>
+    <tr>
+      <td><%= tag.name %></td>
+
+      <td>
+        <span><%= link "Show", to: Routes.tag_path(@conn, :show, tag) %></span>
+        <span><%= link "Edit", to: Routes.tag_path(@conn, :edit, tag) %></span>
+        <span><%= link "Delete", to: Routes.tag_path(@conn, :delete, tag), method: :delete, data: [confirm: "Are you sure?"] %></span>
+      </td>
+    </tr>
+<% end %>
+  </tbody>
+</table>
+
+<span><%= link "New Tag", to: Routes.tag_path(@conn, :new) %></span>

--- a/lib/knowbot_web/templates/tag/new.html.heex
+++ b/lib/knowbot_web/templates/tag/new.html.heex
@@ -1,0 +1,5 @@
+<h1>New Tag</h1>
+
+<%= render "form.html", Map.put(assigns, :action, Routes.tag_path(@conn, :create)) %>
+
+<span><%= link "Back", to: Routes.tag_path(@conn, :index) %></span>

--- a/lib/knowbot_web/templates/tag/show.html.heex
+++ b/lib/knowbot_web/templates/tag/show.html.heex
@@ -1,0 +1,13 @@
+<h1>Show Tag</h1>
+
+<ul>
+
+  <li>
+    <strong>Name:</strong>
+    <%= @tag.name %>
+  </li>
+
+</ul>
+
+<span><%= link "Edit", to: Routes.tag_path(@conn, :edit, @tag) %></span> |
+<span><%= link "Back", to: Routes.tag_path(@conn, :index) %></span>

--- a/lib/knowbot_web/views/answer_view.ex
+++ b/lib/knowbot_web/views/answer_view.ex
@@ -1,0 +1,3 @@
+defmodule KnowbotWeb.AnswerView do
+  use KnowbotWeb, :view
+end

--- a/lib/knowbot_web/views/keyword_view.ex
+++ b/lib/knowbot_web/views/keyword_view.ex
@@ -1,0 +1,3 @@
+defmodule KnowbotWeb.KeywordView do
+  use KnowbotWeb, :view
+end

--- a/lib/knowbot_web/views/question_view.ex
+++ b/lib/knowbot_web/views/question_view.ex
@@ -1,0 +1,3 @@
+defmodule KnowbotWeb.QuestionView do
+  use KnowbotWeb, :view
+end

--- a/lib/knowbot_web/views/tag_view.ex
+++ b/lib/knowbot_web/views/tag_view.ex
@@ -1,0 +1,3 @@
+defmodule KnowbotWeb.TagView do
+  use KnowbotWeb, :view
+end

--- a/priv/repo/migrations/20221223172057_create_tags.exs
+++ b/priv/repo/migrations/20221223172057_create_tags.exs
@@ -1,0 +1,11 @@
+defmodule Knowbot.Repo.Migrations.CreateTags do
+  use Ecto.Migration
+
+  def change do
+    create table(:tags) do
+      add :name, :string
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20221223172143_create_keywords.exs
+++ b/priv/repo/migrations/20221223172143_create_keywords.exs
@@ -1,0 +1,11 @@
+defmodule Knowbot.Repo.Migrations.CreateKeywords do
+  use Ecto.Migration
+
+  def change do
+    create table(:keywords) do
+      add :name, :string
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20221223174810_create_questions.exs
+++ b/priv/repo/migrations/20221223174810_create_questions.exs
@@ -1,0 +1,12 @@
+defmodule Knowbot.Repo.Migrations.CreateQuestions do
+  use Ecto.Migration
+
+  def change do
+    create table(:questions) do
+      add :content, :text
+      add :asker, :string
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20221223175203_create_answers.exs
+++ b/priv/repo/migrations/20221223175203_create_answers.exs
@@ -1,0 +1,12 @@
+defmodule Knowbot.Repo.Migrations.CreateAnswers do
+  use Ecto.Migration
+
+  def change do
+    create table(:answers) do
+      add :content, :text
+      add :answered_by, :string
+
+      timestamps()
+    end
+  end
+end

--- a/test/knowbot/answers_test.exs
+++ b/test/knowbot/answers_test.exs
@@ -1,0 +1,61 @@
+defmodule Knowbot.AnswersTest do
+  use Knowbot.DataCase
+
+  alias Knowbot.Answers
+
+  describe "answers" do
+    alias Knowbot.Answers.Answer
+
+    import Knowbot.AnswersFixtures
+
+    @invalid_attrs %{answered_by: nil, content: nil}
+
+    test "list_answers/0 returns all answers" do
+      answer = answer_fixture()
+      assert Answers.list_answers() == [answer]
+    end
+
+    test "get_answer!/1 returns the answer with given id" do
+      answer = answer_fixture()
+      assert Answers.get_answer!(answer.id) == answer
+    end
+
+    test "create_answer/1 with valid data creates a answer" do
+      valid_attrs = %{answered_by: "some answered_by", content: "some content"}
+
+      assert {:ok, %Answer{} = answer} = Answers.create_answer(valid_attrs)
+      assert answer.answered_by == "some answered_by"
+      assert answer.content == "some content"
+    end
+
+    test "create_answer/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Answers.create_answer(@invalid_attrs)
+    end
+
+    test "update_answer/2 with valid data updates the answer" do
+      answer = answer_fixture()
+      update_attrs = %{answered_by: "some updated answered_by", content: "some updated content"}
+
+      assert {:ok, %Answer{} = answer} = Answers.update_answer(answer, update_attrs)
+      assert answer.answered_by == "some updated answered_by"
+      assert answer.content == "some updated content"
+    end
+
+    test "update_answer/2 with invalid data returns error changeset" do
+      answer = answer_fixture()
+      assert {:error, %Ecto.Changeset{}} = Answers.update_answer(answer, @invalid_attrs)
+      assert answer == Answers.get_answer!(answer.id)
+    end
+
+    test "delete_answer/1 deletes the answer" do
+      answer = answer_fixture()
+      assert {:ok, %Answer{}} = Answers.delete_answer(answer)
+      assert_raise Ecto.NoResultsError, fn -> Answers.get_answer!(answer.id) end
+    end
+
+    test "change_answer/1 returns a answer changeset" do
+      answer = answer_fixture()
+      assert %Ecto.Changeset{} = Answers.change_answer(answer)
+    end
+  end
+end

--- a/test/knowbot/keywords_test.exs
+++ b/test/knowbot/keywords_test.exs
@@ -1,0 +1,59 @@
+defmodule Knowbot.KeywordsTest do
+  use Knowbot.DataCase
+
+  alias Knowbot.Keywords
+
+  describe "keywords" do
+    alias Knowbot.Keywords.Keyword
+
+    import Knowbot.KeywordsFixtures
+
+    @invalid_attrs %{name: nil}
+
+    test "list_keywords/0 returns all keywords" do
+      keyword = keyword_fixture()
+      assert Keywords.list_keywords() == [keyword]
+    end
+
+    test "get_keyword!/1 returns the keyword with given id" do
+      keyword = keyword_fixture()
+      assert Keywords.get_keyword!(keyword.id) == keyword
+    end
+
+    test "create_keyword/1 with valid data creates a keyword" do
+      valid_attrs = %{name: "some name"}
+
+      assert {:ok, %Keyword{} = keyword} = Keywords.create_keyword(valid_attrs)
+      assert keyword.name == "some name"
+    end
+
+    test "create_keyword/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Keywords.create_keyword(@invalid_attrs)
+    end
+
+    test "update_keyword/2 with valid data updates the keyword" do
+      keyword = keyword_fixture()
+      update_attrs = %{name: "some updated name"}
+
+      assert {:ok, %Keyword{} = keyword} = Keywords.update_keyword(keyword, update_attrs)
+      assert keyword.name == "some updated name"
+    end
+
+    test "update_keyword/2 with invalid data returns error changeset" do
+      keyword = keyword_fixture()
+      assert {:error, %Ecto.Changeset{}} = Keywords.update_keyword(keyword, @invalid_attrs)
+      assert keyword == Keywords.get_keyword!(keyword.id)
+    end
+
+    test "delete_keyword/1 deletes the keyword" do
+      keyword = keyword_fixture()
+      assert {:ok, %Keyword{}} = Keywords.delete_keyword(keyword)
+      assert_raise Ecto.NoResultsError, fn -> Keywords.get_keyword!(keyword.id) end
+    end
+
+    test "change_keyword/1 returns a keyword changeset" do
+      keyword = keyword_fixture()
+      assert %Ecto.Changeset{} = Keywords.change_keyword(keyword)
+    end
+  end
+end

--- a/test/knowbot/questions_test.exs
+++ b/test/knowbot/questions_test.exs
@@ -1,0 +1,61 @@
+defmodule Knowbot.QuestionsTest do
+  use Knowbot.DataCase
+
+  alias Knowbot.Questions
+
+  describe "questions" do
+    alias Knowbot.Questions.Question
+
+    import Knowbot.QuestionsFixtures
+
+    @invalid_attrs %{asker: nil, content: nil}
+
+    test "list_questions/0 returns all questions" do
+      question = question_fixture()
+      assert Questions.list_questions() == [question]
+    end
+
+    test "get_question!/1 returns the question with given id" do
+      question = question_fixture()
+      assert Questions.get_question!(question.id) == question
+    end
+
+    test "create_question/1 with valid data creates a question" do
+      valid_attrs = %{asker: "some asker", content: "some content"}
+
+      assert {:ok, %Question{} = question} = Questions.create_question(valid_attrs)
+      assert question.asker == "some asker"
+      assert question.content == "some content"
+    end
+
+    test "create_question/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Questions.create_question(@invalid_attrs)
+    end
+
+    test "update_question/2 with valid data updates the question" do
+      question = question_fixture()
+      update_attrs = %{asker: "some updated asker", content: "some updated content"}
+
+      assert {:ok, %Question{} = question} = Questions.update_question(question, update_attrs)
+      assert question.asker == "some updated asker"
+      assert question.content == "some updated content"
+    end
+
+    test "update_question/2 with invalid data returns error changeset" do
+      question = question_fixture()
+      assert {:error, %Ecto.Changeset{}} = Questions.update_question(question, @invalid_attrs)
+      assert question == Questions.get_question!(question.id)
+    end
+
+    test "delete_question/1 deletes the question" do
+      question = question_fixture()
+      assert {:ok, %Question{}} = Questions.delete_question(question)
+      assert_raise Ecto.NoResultsError, fn -> Questions.get_question!(question.id) end
+    end
+
+    test "change_question/1 returns a question changeset" do
+      question = question_fixture()
+      assert %Ecto.Changeset{} = Questions.change_question(question)
+    end
+  end
+end

--- a/test/knowbot/tags_test.exs
+++ b/test/knowbot/tags_test.exs
@@ -1,0 +1,59 @@
+defmodule Knowbot.TagsTest do
+  use Knowbot.DataCase
+
+  alias Knowbot.Tags
+
+  describe "tags" do
+    alias Knowbot.Tags.Tag
+
+    import Knowbot.TagsFixtures
+
+    @invalid_attrs %{name: nil}
+
+    test "list_tags/0 returns all tags" do
+      tag = tag_fixture()
+      assert Tags.list_tags() == [tag]
+    end
+
+    test "get_tag!/1 returns the tag with given id" do
+      tag = tag_fixture()
+      assert Tags.get_tag!(tag.id) == tag
+    end
+
+    test "create_tag/1 with valid data creates a tag" do
+      valid_attrs = %{name: "some name"}
+
+      assert {:ok, %Tag{} = tag} = Tags.create_tag(valid_attrs)
+      assert tag.name == "some name"
+    end
+
+    test "create_tag/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Tags.create_tag(@invalid_attrs)
+    end
+
+    test "update_tag/2 with valid data updates the tag" do
+      tag = tag_fixture()
+      update_attrs = %{name: "some updated name"}
+
+      assert {:ok, %Tag{} = tag} = Tags.update_tag(tag, update_attrs)
+      assert tag.name == "some updated name"
+    end
+
+    test "update_tag/2 with invalid data returns error changeset" do
+      tag = tag_fixture()
+      assert {:error, %Ecto.Changeset{}} = Tags.update_tag(tag, @invalid_attrs)
+      assert tag == Tags.get_tag!(tag.id)
+    end
+
+    test "delete_tag/1 deletes the tag" do
+      tag = tag_fixture()
+      assert {:ok, %Tag{}} = Tags.delete_tag(tag)
+      assert_raise Ecto.NoResultsError, fn -> Tags.get_tag!(tag.id) end
+    end
+
+    test "change_tag/1 returns a tag changeset" do
+      tag = tag_fixture()
+      assert %Ecto.Changeset{} = Tags.change_tag(tag)
+    end
+  end
+end

--- a/test/knowbot_web/controllers/answer_controller_test.exs
+++ b/test/knowbot_web/controllers/answer_controller_test.exs
@@ -1,0 +1,84 @@
+defmodule KnowbotWeb.AnswerControllerTest do
+  use KnowbotWeb.ConnCase
+
+  import Knowbot.AnswersFixtures
+
+  @create_attrs %{answered_by: "some answered_by", content: "some content"}
+  @update_attrs %{answered_by: "some updated answered_by", content: "some updated content"}
+  @invalid_attrs %{answered_by: nil, content: nil}
+
+  describe "index" do
+    test "lists all answers", %{conn: conn} do
+      conn = get(conn, Routes.answer_path(conn, :index))
+      assert html_response(conn, 200) =~ "Listing Answers"
+    end
+  end
+
+  describe "new answer" do
+    test "renders form", %{conn: conn} do
+      conn = get(conn, Routes.answer_path(conn, :new))
+      assert html_response(conn, 200) =~ "New Answer"
+    end
+  end
+
+  describe "create answer" do
+    test "redirects to show when data is valid", %{conn: conn} do
+      conn = post(conn, Routes.answer_path(conn, :create), answer: @create_attrs)
+
+      assert %{id: id} = redirected_params(conn)
+      assert redirected_to(conn) == Routes.answer_path(conn, :show, id)
+
+      conn = get(conn, Routes.answer_path(conn, :show, id))
+      assert html_response(conn, 200) =~ "Show Answer"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, Routes.answer_path(conn, :create), answer: @invalid_attrs)
+      assert html_response(conn, 200) =~ "New Answer"
+    end
+  end
+
+  describe "edit answer" do
+    setup [:create_answer]
+
+    test "renders form for editing chosen answer", %{conn: conn, answer: answer} do
+      conn = get(conn, Routes.answer_path(conn, :edit, answer))
+      assert html_response(conn, 200) =~ "Edit Answer"
+    end
+  end
+
+  describe "update answer" do
+    setup [:create_answer]
+
+    test "redirects when data is valid", %{conn: conn, answer: answer} do
+      conn = put(conn, Routes.answer_path(conn, :update, answer), answer: @update_attrs)
+      assert redirected_to(conn) == Routes.answer_path(conn, :show, answer)
+
+      conn = get(conn, Routes.answer_path(conn, :show, answer))
+      assert html_response(conn, 200) =~ "some updated answered_by"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, answer: answer} do
+      conn = put(conn, Routes.answer_path(conn, :update, answer), answer: @invalid_attrs)
+      assert html_response(conn, 200) =~ "Edit Answer"
+    end
+  end
+
+  describe "delete answer" do
+    setup [:create_answer]
+
+    test "deletes chosen answer", %{conn: conn, answer: answer} do
+      conn = delete(conn, Routes.answer_path(conn, :delete, answer))
+      assert redirected_to(conn) == Routes.answer_path(conn, :index)
+
+      assert_error_sent 404, fn ->
+        get(conn, Routes.answer_path(conn, :show, answer))
+      end
+    end
+  end
+
+  defp create_answer(_) do
+    answer = answer_fixture()
+    %{answer: answer}
+  end
+end

--- a/test/knowbot_web/controllers/keyword_controller_test.exs
+++ b/test/knowbot_web/controllers/keyword_controller_test.exs
@@ -1,0 +1,84 @@
+defmodule KnowbotWeb.KeywordControllerTest do
+  use KnowbotWeb.ConnCase
+
+  import Knowbot.KeywordsFixtures
+
+  @create_attrs %{name: "some name"}
+  @update_attrs %{name: "some updated name"}
+  @invalid_attrs %{name: nil}
+
+  describe "index" do
+    test "lists all keywords", %{conn: conn} do
+      conn = get(conn, Routes.keyword_path(conn, :index))
+      assert html_response(conn, 200) =~ "Listing Keywords"
+    end
+  end
+
+  describe "new keyword" do
+    test "renders form", %{conn: conn} do
+      conn = get(conn, Routes.keyword_path(conn, :new))
+      assert html_response(conn, 200) =~ "New Keyword"
+    end
+  end
+
+  describe "create keyword" do
+    test "redirects to show when data is valid", %{conn: conn} do
+      conn = post(conn, Routes.keyword_path(conn, :create), keyword: @create_attrs)
+
+      assert %{id: id} = redirected_params(conn)
+      assert redirected_to(conn) == Routes.keyword_path(conn, :show, id)
+
+      conn = get(conn, Routes.keyword_path(conn, :show, id))
+      assert html_response(conn, 200) =~ "Show Keyword"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, Routes.keyword_path(conn, :create), keyword: @invalid_attrs)
+      assert html_response(conn, 200) =~ "New Keyword"
+    end
+  end
+
+  describe "edit keyword" do
+    setup [:create_keyword]
+
+    test "renders form for editing chosen keyword", %{conn: conn, keyword: keyword} do
+      conn = get(conn, Routes.keyword_path(conn, :edit, keyword))
+      assert html_response(conn, 200) =~ "Edit Keyword"
+    end
+  end
+
+  describe "update keyword" do
+    setup [:create_keyword]
+
+    test "redirects when data is valid", %{conn: conn, keyword: keyword} do
+      conn = put(conn, Routes.keyword_path(conn, :update, keyword), keyword: @update_attrs)
+      assert redirected_to(conn) == Routes.keyword_path(conn, :show, keyword)
+
+      conn = get(conn, Routes.keyword_path(conn, :show, keyword))
+      assert html_response(conn, 200) =~ "some updated name"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, keyword: keyword} do
+      conn = put(conn, Routes.keyword_path(conn, :update, keyword), keyword: @invalid_attrs)
+      assert html_response(conn, 200) =~ "Edit Keyword"
+    end
+  end
+
+  describe "delete keyword" do
+    setup [:create_keyword]
+
+    test "deletes chosen keyword", %{conn: conn, keyword: keyword} do
+      conn = delete(conn, Routes.keyword_path(conn, :delete, keyword))
+      assert redirected_to(conn) == Routes.keyword_path(conn, :index)
+
+      assert_error_sent 404, fn ->
+        get(conn, Routes.keyword_path(conn, :show, keyword))
+      end
+    end
+  end
+
+  defp create_keyword(_) do
+    keyword = keyword_fixture()
+    %{keyword: keyword}
+  end
+end

--- a/test/knowbot_web/controllers/question_controller_test.exs
+++ b/test/knowbot_web/controllers/question_controller_test.exs
@@ -1,0 +1,84 @@
+defmodule KnowbotWeb.QuestionControllerTest do
+  use KnowbotWeb.ConnCase
+
+  import Knowbot.QuestionsFixtures
+
+  @create_attrs %{asker: "some asker", content: "some content"}
+  @update_attrs %{asker: "some updated asker", content: "some updated content"}
+  @invalid_attrs %{asker: nil, content: nil}
+
+  describe "index" do
+    test "lists all questions", %{conn: conn} do
+      conn = get(conn, Routes.question_path(conn, :index))
+      assert html_response(conn, 200) =~ "Listing Questions"
+    end
+  end
+
+  describe "new question" do
+    test "renders form", %{conn: conn} do
+      conn = get(conn, Routes.question_path(conn, :new))
+      assert html_response(conn, 200) =~ "New Question"
+    end
+  end
+
+  describe "create question" do
+    test "redirects to show when data is valid", %{conn: conn} do
+      conn = post(conn, Routes.question_path(conn, :create), question: @create_attrs)
+
+      assert %{id: id} = redirected_params(conn)
+      assert redirected_to(conn) == Routes.question_path(conn, :show, id)
+
+      conn = get(conn, Routes.question_path(conn, :show, id))
+      assert html_response(conn, 200) =~ "Show Question"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, Routes.question_path(conn, :create), question: @invalid_attrs)
+      assert html_response(conn, 200) =~ "New Question"
+    end
+  end
+
+  describe "edit question" do
+    setup [:create_question]
+
+    test "renders form for editing chosen question", %{conn: conn, question: question} do
+      conn = get(conn, Routes.question_path(conn, :edit, question))
+      assert html_response(conn, 200) =~ "Edit Question"
+    end
+  end
+
+  describe "update question" do
+    setup [:create_question]
+
+    test "redirects when data is valid", %{conn: conn, question: question} do
+      conn = put(conn, Routes.question_path(conn, :update, question), question: @update_attrs)
+      assert redirected_to(conn) == Routes.question_path(conn, :show, question)
+
+      conn = get(conn, Routes.question_path(conn, :show, question))
+      assert html_response(conn, 200) =~ "some updated asker"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, question: question} do
+      conn = put(conn, Routes.question_path(conn, :update, question), question: @invalid_attrs)
+      assert html_response(conn, 200) =~ "Edit Question"
+    end
+  end
+
+  describe "delete question" do
+    setup [:create_question]
+
+    test "deletes chosen question", %{conn: conn, question: question} do
+      conn = delete(conn, Routes.question_path(conn, :delete, question))
+      assert redirected_to(conn) == Routes.question_path(conn, :index)
+
+      assert_error_sent 404, fn ->
+        get(conn, Routes.question_path(conn, :show, question))
+      end
+    end
+  end
+
+  defp create_question(_) do
+    question = question_fixture()
+    %{question: question}
+  end
+end

--- a/test/knowbot_web/controllers/tag_controller_test.exs
+++ b/test/knowbot_web/controllers/tag_controller_test.exs
@@ -1,0 +1,84 @@
+defmodule KnowbotWeb.TagControllerTest do
+  use KnowbotWeb.ConnCase
+
+  import Knowbot.TagsFixtures
+
+  @create_attrs %{name: "some name"}
+  @update_attrs %{name: "some updated name"}
+  @invalid_attrs %{name: nil}
+
+  describe "index" do
+    test "lists all tags", %{conn: conn} do
+      conn = get(conn, Routes.tag_path(conn, :index))
+      assert html_response(conn, 200) =~ "Listing Tags"
+    end
+  end
+
+  describe "new tag" do
+    test "renders form", %{conn: conn} do
+      conn = get(conn, Routes.tag_path(conn, :new))
+      assert html_response(conn, 200) =~ "New Tag"
+    end
+  end
+
+  describe "create tag" do
+    test "redirects to show when data is valid", %{conn: conn} do
+      conn = post(conn, Routes.tag_path(conn, :create), tag: @create_attrs)
+
+      assert %{id: id} = redirected_params(conn)
+      assert redirected_to(conn) == Routes.tag_path(conn, :show, id)
+
+      conn = get(conn, Routes.tag_path(conn, :show, id))
+      assert html_response(conn, 200) =~ "Show Tag"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, Routes.tag_path(conn, :create), tag: @invalid_attrs)
+      assert html_response(conn, 200) =~ "New Tag"
+    end
+  end
+
+  describe "edit tag" do
+    setup [:create_tag]
+
+    test "renders form for editing chosen tag", %{conn: conn, tag: tag} do
+      conn = get(conn, Routes.tag_path(conn, :edit, tag))
+      assert html_response(conn, 200) =~ "Edit Tag"
+    end
+  end
+
+  describe "update tag" do
+    setup [:create_tag]
+
+    test "redirects when data is valid", %{conn: conn, tag: tag} do
+      conn = put(conn, Routes.tag_path(conn, :update, tag), tag: @update_attrs)
+      assert redirected_to(conn) == Routes.tag_path(conn, :show, tag)
+
+      conn = get(conn, Routes.tag_path(conn, :show, tag))
+      assert html_response(conn, 200) =~ "some updated name"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, tag: tag} do
+      conn = put(conn, Routes.tag_path(conn, :update, tag), tag: @invalid_attrs)
+      assert html_response(conn, 200) =~ "Edit Tag"
+    end
+  end
+
+  describe "delete tag" do
+    setup [:create_tag]
+
+    test "deletes chosen tag", %{conn: conn, tag: tag} do
+      conn = delete(conn, Routes.tag_path(conn, :delete, tag))
+      assert redirected_to(conn) == Routes.tag_path(conn, :index)
+
+      assert_error_sent 404, fn ->
+        get(conn, Routes.tag_path(conn, :show, tag))
+      end
+    end
+  end
+
+  defp create_tag(_) do
+    tag = tag_fixture()
+    %{tag: tag}
+  end
+end

--- a/test/support/fixtures/answers_fixtures.ex
+++ b/test/support/fixtures/answers_fixtures.ex
@@ -1,0 +1,21 @@
+defmodule Knowbot.AnswersFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Knowbot.Answers` context.
+  """
+
+  @doc """
+  Generate a answer.
+  """
+  def answer_fixture(attrs \\ %{}) do
+    {:ok, answer} =
+      attrs
+      |> Enum.into(%{
+        answered_by: "some answered_by",
+        content: "some content"
+      })
+      |> Knowbot.Answers.create_answer()
+
+    answer
+  end
+end

--- a/test/support/fixtures/keywords_fixtures.ex
+++ b/test/support/fixtures/keywords_fixtures.ex
@@ -1,0 +1,20 @@
+defmodule Knowbot.KeywordsFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Knowbot.Keywords` context.
+  """
+
+  @doc """
+  Generate a keyword.
+  """
+  def keyword_fixture(attrs \\ %{}) do
+    {:ok, keyword} =
+      attrs
+      |> Enum.into(%{
+        name: "some name"
+      })
+      |> Knowbot.Keywords.create_keyword()
+
+    keyword
+  end
+end

--- a/test/support/fixtures/questions_fixtures.ex
+++ b/test/support/fixtures/questions_fixtures.ex
@@ -1,0 +1,21 @@
+defmodule Knowbot.QuestionsFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Knowbot.Questions` context.
+  """
+
+  @doc """
+  Generate a question.
+  """
+  def question_fixture(attrs \\ %{}) do
+    {:ok, question} =
+      attrs
+      |> Enum.into(%{
+        asker: "some asker",
+        content: "some content"
+      })
+      |> Knowbot.Questions.create_question()
+
+    question
+  end
+end

--- a/test/support/fixtures/tags_fixtures.ex
+++ b/test/support/fixtures/tags_fixtures.ex
@@ -1,0 +1,20 @@
+defmodule Knowbot.TagsFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Knowbot.Tags` context.
+  """
+
+  @doc """
+  Generate a tag.
+  """
+  def tag_fixture(attrs \\ %{}) do
+    {:ok, tag} =
+      attrs
+      |> Enum.into(%{
+        name: "some name"
+      })
+      |> Knowbot.Tags.create_tag()
+
+    tag
+  end
+end


### PR DESCRIPTION
Aside from some (incomplete) experimentation with ENV variables handling, this PR focuses on creating the initial data model: 

- Create the Questions and Answers tables, along with Tag and Keyword tables.
- Implement (a hack) to record user questions (via bot input) in the Questions table.