### PR TITLE
Fix tests after adding auth & many-to-many between questions and answers

### DIFF
--- a/lib/knowbot/answers.ex
+++ b/lib/knowbot/answers.ex
@@ -17,7 +17,7 @@ defmodule Knowbot.Answers do
 
   """
   def list_answers do
-    Repo.all(Answer)
+    Repo.all(Answer) |> Repo.preload(:questions)
   end
 
   @doc """
@@ -34,7 +34,7 @@ defmodule Knowbot.Answers do
       ** (Ecto.NoResultsError)
 
   """
-  def get_answer!(id), do: Repo.get!(Answer, id)
+  def get_answer!(id), do: Repo.get!(Answer, id) |> Repo.preload(:questions)
 
   @doc """
   Creates a answer.

--- a/lib/knowbot/questions.ex
+++ b/lib/knowbot/questions.ex
@@ -17,7 +17,7 @@ defmodule Knowbot.Questions do
 
   """
   def list_questions do
-    Repo.all(Question)
+    Repo.all(Question) |> Repo.preload(:answers)
   end
 
   @doc """
@@ -34,7 +34,7 @@ defmodule Knowbot.Questions do
       ** (Ecto.NoResultsError)
 
   """
-  def get_question!(id), do: Repo.get!(Question, id)
+  def get_question!(id), do: Repo.get!(Question, id) |> Repo.preload(:answers)
 
   @doc """
   Creates a question.
@@ -57,9 +57,9 @@ defmodule Knowbot.Questions do
   #   |> Repo.insert()
   # end
 
-  def create_question(attrs \\ %{}) do
+  def create_question(attrs \\ %{}, answers \\ []) do
     %Question{}
-    |> Question.changeset(attrs)
+    |> Question.changeset(attrs, answers)
     |> Repo.insert()
   end
 

--- a/lib/knowbot_web/controllers/answer_controller.ex
+++ b/lib/knowbot_web/controllers/answer_controller.ex
@@ -5,7 +5,7 @@ defmodule KnowbotWeb.AnswerController do
   alias Knowbot.Answers.Answer
 
   def index(conn, _params) do
-    answers = Answers.list_answers()
+    answers = Answers.list_answers() |> Knowbot.Repo.preload([:questions])
     render(conn, "index.html", answers: answers)
   end
 
@@ -27,18 +27,18 @@ defmodule KnowbotWeb.AnswerController do
   end
 
   def show(conn, %{"id" => id}) do
-    answer = Answers.get_answer!(id)
+    answer = Answers.get_answer!(id) |> Knowbot.Repo.preload([:questions])
     render(conn, "show.html", answer: answer)
   end
 
   def edit(conn, %{"id" => id}) do
-    answer = Answers.get_answer!(id)
+    answer = Answers.get_answer!(id) |> Knowbot.Repo.preload([:questions])
     changeset = Answers.change_answer(answer)
     render(conn, "edit.html", answer: answer, changeset: changeset)
   end
 
   def update(conn, %{"id" => id, "answer" => answer_params}) do
-    answer = Answers.get_answer!(id)
+    answer = Answers.get_answer!(id) |> Knowbot.Repo.preload([:questions])
 
     case Answers.update_answer(answer, answer_params) do
       {:ok, answer} ->

--- a/lib/knowbot_web/controllers/question_controller.ex
+++ b/lib/knowbot_web/controllers/question_controller.ex
@@ -3,9 +3,10 @@ defmodule KnowbotWeb.QuestionController do
 
   alias Knowbot.Questions
   alias Knowbot.Questions.Question
+  alias Knowbot.Repo
 
   def index(conn, _params) do
-    questions = Questions.list_questions()
+    questions = Questions.list_questions() |> Knowbot.Repo.preload([:answers])
     render(conn, "index.html", questions: questions)
   end
 
@@ -27,18 +28,18 @@ defmodule KnowbotWeb.QuestionController do
   end
 
   def show(conn, %{"id" => id}) do
-    question = Questions.get_question!(id)
+    question = Questions.get_question!(id) |> Knowbot.Repo.preload([:answers])
     render(conn, "show.html", question: question)
   end
 
   def edit(conn, %{"id" => id}) do
-    question = Questions.get_question!(id)
+    question = Questions.get_question!(id) |> Knowbot.Repo.preload([:answers])
     changeset = Questions.change_question(question)
     render(conn, "edit.html", question: question, changeset: changeset)
   end
 
   def update(conn, %{"id" => id, "question" => question_params}) do
-    question = Questions.get_question!(id)
+    question = Questions.get_question!(id) |> Knowbot.Repo.preload([:answers])
 
     case Questions.update_question(question, question_params) do
       {:ok, question} ->

--- a/test/knowbot/answers_test.exs
+++ b/test/knowbot/answers_test.exs
@@ -1,11 +1,9 @@
 defmodule Knowbot.AnswersTest do
   use Knowbot.DataCase
-
   alias Knowbot.Answers
 
   describe "answers" do
     alias Knowbot.Answers.Answer
-
     import Knowbot.AnswersFixtures
     import Knowbot.QuestionsFixtures
 

--- a/test/knowbot/questions_test.exs
+++ b/test/knowbot/questions_test.exs
@@ -1,12 +1,11 @@
 defmodule Knowbot.QuestionsTest do
   use Knowbot.DataCase
-
   alias Knowbot.Questions
 
   describe "questions" do
     alias Knowbot.Questions.Question
-
     import Knowbot.QuestionsFixtures
+    import Knowbot.AnswersFixtures
 
     @invalid_attrs %{asker: nil, content: nil}
 
@@ -26,6 +25,16 @@ defmodule Knowbot.QuestionsTest do
       assert {:ok, %Question{} = question} = Questions.create_question(valid_attrs)
       assert question.asker == "some asker"
       assert question.content == "some content"
+    end
+
+    test "create_question/2 with associated answer" do
+      answer = answer_fixture()
+      valid_attrs = %{asker: "some asker", content: "some content"}
+
+      assert {:ok, %Question{} = question} = Questions.create_question(valid_attrs, [answer] )
+      assert question.asker == "some asker"
+      assert question.content == "some content"
+      assert question.answers == [answer]
     end
 
     test "create_question/1 with invalid data returns error changeset" do

--- a/test/knowbot_web/controllers/answer_controller_test.exs
+++ b/test/knowbot_web/controllers/answer_controller_test.exs
@@ -7,6 +7,8 @@ defmodule KnowbotWeb.AnswerControllerTest do
   @update_attrs %{answered_by: "some updated answered_by", content: "some updated content"}
   @invalid_attrs %{answered_by: nil, content: nil}
 
+  setup :register_and_log_in_user
+
   describe "index" do
     test "lists all answers", %{conn: conn} do
       conn = get(conn, Routes.answer_path(conn, :index))


### PR DESCRIPTION
Refactored tests to correctly handle the /answers route being protected, as well as properly reflecting the many-to-many associations between Questions and Answers.